### PR TITLE
Make many hard coded values overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ in the next section of this document.
 * Create a playbook that references the *ansible-nagios-config* role, and use it to deploy
 your configuration.
 
+Configuration
+-------------
+
+* **nagios_base_dir:** the nagios installation directory. *default: /usr/local/nagios*
+* **nagios_object_dir:** the nagios object directory. *default: {{nagios_base_dir}}/etc/objects*
+* **nagios_cfg_dir_enabled:** if true, configures nagios_object_dir as a cfg_dir. *default: false*
+* **nagios_user:** id of nagios user. *default: nagios*
+* **nagios_group:** id of nagios group. *default: nagios*
+
 nagios_hosts
 ------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,79 +1,37 @@
-# Hosts.
-- name: create hosts.cfg
+- name: Install config files
   sudo: true
   notify: restart nagios
   template: >
-    src=hosts.cfg
-    dest=/usr/local/nagios/etc/objects/hosts.cfg
-    owner=nagios
-    group=nagios
+    src={{item.src}}
+    dest={{nagios_object_dir}}/{{item.dest}}
+    owner={{nagios_user}}
+    group={{nagios_group}}
     mode=640
+  with_items:
+    - { src: hosts.cfg, dest: hosts.cfg }
+    - { src: hostgroups.cfg, dest: hostgroups.cfg }
+    - { src: services.cfg, dest: services.cfg }
+    - { src: commands.cfg, dest: additional_commands.cfg }
 
-- name: load hosts.cfg
+- name: Update nagios.cfg with config files
   sudo: true
   notify: restart nagios
   lineinfile: >
-    dest=/usr/local/nagios/etc/nagios.cfg
-    line="cfg_file=/usr/local/nagios/etc/objects/hosts.cfg"
-    regexp="^cfg_file\=/usr/local/nagios/etc/objects/hosts\.cfg"
-    state=present
+    dest={{nagios_base_dir}}/etc/nagios.cfg
+    line="cfg_file={{nagios_object_dir}}/{{item}}.cfg"
+    regexp="^cfg_file\={{nagios_object_dir}}/{{item}}\.cfg"
+  with_items:
+    - hosts
+    - hostgroups
+    - services
+    - additional_commands
+  when: nagios_cfg_dir_enabled == false
 
-# Host Groups.
-- name: create hostgroups.cfg
-  sudo: true
-  notify: restart nagios
-  template: >
-    src=hostgroups.cfg
-    dest=/usr/local/nagios/etc/objects/hostgroups.cfg
-    owner=nagios
-    group=nagios
-    mode=640
-
-- name: load hostgroups.cfg
+- name: Update nagios.cfg with config dir
   sudo: true
   notify: restart nagios
   lineinfile: >
-    dest=/usr/local/nagios/etc/nagios.cfg
-    line="cfg_file=/usr/local/nagios/etc/objects/hostgroups.cfg"
-    regexp="^cfg_file\=/usr/local/nagios/etc/objects/hostgroups\.cfg"
-    state=present
-
-# Additional Commands
-- name: create additional_commands.cfg
-  sudo: true
-  notify: restart nagios
-  template: >
-    src=commands.cfg
-    dest=/usr/local/nagios/etc/objects/additional_commands.cfg
-    owner=nagios
-    group=nagios
-    mode=640
-
-- name: load additional_commands.cfg
-  sudo: true
-  notify: restart nagios
-  lineinfile: >
-    dest=/usr/local/nagios/etc/nagios.cfg
-    line="cfg_file=/usr/local/nagios/etc/objects/additional_commands.cfg"
-    regexp="^cfg_file\=/usr/local/nagios/etc/objects/additional_commands\.cfg"
-    state=present
-
-# Services.
-- name: create services.cfg
-  sudo: true
-  notify: restart nagios
-  template: >
-    src=services.cfg
-    dest=/usr/local/nagios/etc/objects/services.cfg
-    owner=nagios
-    group=nagios
-    mode=640
-
-- name: load services.cfg
-  sudo: true
-  notify: restart nagios
-  lineinfile: >
-    dest=/usr/local/nagios/etc/nagios.cfg
-    line="cfg_file=/usr/local/nagios/etc/objects/services.cfg"
-    regexp="^cfg_file\=/usr/local/nagios/etc/objects/services\.cfg"
-    state=present
+    dest={{nagios_base_dir}}/etc/nagios.cfg
+    line="cfg_dir={{nagios_object_dir}}"
+    regexp="^cfg_dir={{nagios_object_dir}}"
+  when: nagios_cfg_dir_enabled == true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,15 @@
+# base directory for nagios installation
+nagios_base_dir: /usr/local/nagios
+
+# nagios object directory
+nagios_object_dir: "{{nagios_base_dir}}/etc/objects"
+
+# if true, nagios_object_dir is a cfg_dir and nagios will
+# autoload all files ending in .cfg
+nagios_cfg_dir_enabled: false
+
+# id of nagios user
+nagios_user: nagios
+
+# id of nagios group
+nagios_group: nagios


### PR DESCRIPTION
- Add the ability to specify object dir is a cfg_dir so we
  don't need to add config files to nagios.cfg explicitly
- Simplified the main task file down to two tasks that process
  multiple files
