### PR TITLE
6 - Invert Host and HostGroup Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,12 @@ Used to describe the hosts you would like to monitor with Nagios:
 
 * **name:** the name of the host, used to reference it in *host_groups.*
 * **address:** the actual address of the host.
-* *other variables:* other variables represent *host_groups* that the host
-belongs to, e.g., `www`, `aws`.
+* **groups:** represent the *hostgroups* the host belongs to
 
 ```yaml
 nagios_hosts:
-  - {name: 'www', address: 'www.example.com', www: true, aws: true}
-  - {name: 'redis', address: 'redis.example.com', redis: true, aws: true}
+  - {name: 'www', address: 'www.example.com', groups: { www: true, aws: true } }
+  - {name: 'redis', address: 'redis.example.com', groups: { redis: true, aws: true } }
 ```
 
 nagios_groups

--- a/templates/hostgroups.cfg
+++ b/templates/hostgroups.cfg
@@ -2,6 +2,5 @@
 define hostgroup {
   hostgroup_name  {{host_group.name}};
   alias  {{host_group.alias}};
-  members  {{nagios_hosts|selectattr(host_group.name, 'defined')|map(attribute='name')|join(',')}};
 }
 {% endfor %}

--- a/templates/hosts.cfg
+++ b/templates/hosts.cfg
@@ -23,5 +23,6 @@ define host{
   host_name   {{host.name}}
   alias       {{host.address}}
   address     {{host.address}}
+  hostgroups  {{host.groups|join(',')}}
 }
 {% endfor %}


### PR DESCRIPTION
* Remove 'members' definition from hostgroups template
* Add new 'groups' list to host definitions
* Update README to reflect changes

This addresses #6, as we have encountered the problem where we have dynamic host definitions and require hostgroups to be empty sometimes.

Note: This is not backwards compatible, as it adds the 'groups' list to the host definitions.  If you would like, I can adjust my changes to be more backwards friendly but it may not be as pretty :smile: 