### PR TITLE
Parameterize host check_command

### DIFF
--- a/templates/hosts.cfg
+++ b/templates/hosts.cfg
@@ -23,6 +23,9 @@ define host{
   host_name             {{host.name}}
   alias                 {{host.address}}
   address               {{host.address}}
+{% if host.check_command|default(false) %}
+  check_command        {{host.check_command}}
+{% endif %}
 {% if host.contact_groups|default(false) %}
   contact_groups        {{host.contact_groups}}
 {% endif %}


### PR DESCRIPTION
This allows us to use alternate methods to check whether a machine is
up.  We need to do this for machines with IPv6 because nagios's
check_ping command fails for them unless we use the -4 flag.